### PR TITLE
Fix/return path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -480,7 +480,7 @@ Full List of Settings
   http://docs.aws.amazon.com/general/latest/gr/rande.html
 
 ``AWS_SES_FROM_EMAIL``
-  Optional. The email addres use as the "From" address for the email. The address that you specify has to be verified.  
+  Optional. The email addres to be used as the "From" address for the email. The address that you specify has to be verified.  
   For more information please refer to http://aws.amazon.com/ses/faqs/#38
 
 ``AWS_SES_RETURN_PATH``

--- a/README.rst
+++ b/README.rst
@@ -480,7 +480,7 @@ Full List of Settings
   http://docs.aws.amazon.com/general/latest/gr/rande.html
 
 ``AWS_SES_FROM_EMAIL``
-  Optional. The email addres to be used as the "From" address for the email. The address that you specify has to be verified.  
+  Optional. The email address to be used as the "From" address for the email. The address that you specify has to be verified.  
   For more information please refer to http://aws.amazon.com/ses/faqs/#38
 
 ``AWS_SES_RETURN_PATH``

--- a/README.rst
+++ b/README.rst
@@ -481,6 +481,7 @@ Full List of Settings
 
 ``AWS_SES_RETURN_PATH``
   Instruct Amazon SES to forward bounced emails and complaints to this email.
+  Works only v2 client.
   For more information please refer to http://aws.amazon.com/ses/faqs/#38
 
 ``AWS_SES_CONFIGURATION_SET``

--- a/README.rst
+++ b/README.rst
@@ -481,7 +481,7 @@ Full List of Settings
 
 ``AWS_SES_RETURN_PATH``
   Instruct Amazon SES to forward bounced emails and complaints to this email.
-  Works only v2 client.
+  It only works in the v2 client.
   For more information please refer to http://aws.amazon.com/ses/faqs/#38
 
 ``AWS_SES_CONFIGURATION_SET``

--- a/README.rst
+++ b/README.rst
@@ -485,7 +485,7 @@ Full List of Settings
 
 ``AWS_SES_RETURN_PATH``
   Optional. Use `AWS_SES_RETURN_PATH` to receive complaint notifications
-  It only works in the v2 client.
+  You must use the v2 client by setting `USE_SES_V2=True` for this setting to work, otherwise it is ignored.
   https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendEmail.html#API_SendEmail_RequestSyntax
 
 

--- a/README.rst
+++ b/README.rst
@@ -479,10 +479,15 @@ Full List of Settings
   http://readthedocs.org/docs/boto/en/latest/ref/ses.html#boto.ses.regions
   http://docs.aws.amazon.com/general/latest/gr/rande.html
 
-``AWS_SES_RETURN_PATH``
-  Instruct Amazon SES to forward bounced emails and complaints to this email.
-  It only works in the v2 client.
+``AWS_SES_FROM_EMAIL``
+  Optional. The email addres use as the "From" address for the email. The address that you specify has to be verified.  
   For more information please refer to http://aws.amazon.com/ses/faqs/#38
+
+``AWS_SES_RETURN_PATH``
+  Optional. Use `AWS_SES_RETURN_PATH` to receive complaint notifications
+  It only works in the v2 client.
+  https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendEmail.html#API_SendEmail_RequestSyntax
+
 
 ``AWS_SES_CONFIGURATION_SET``
   Optional. Use this to mark your e-mails as from being from a particular SES

--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -239,16 +239,18 @@ class SESBackend(BaseEmailBackend):
         # end of throttling
 
     def _get_send_email_parameters(self, message, source):
-        return (self._get_v2_parameters(message, source)
+        email_feedback = settings.AWS_SES_FROM_EMAIL
+        return (self._get_v2_parameters(message, source, email_feedback)
                 if self._use_ses_v2
                 else self._get_v1_parameters(message, source))
 
-    def _get_v2_parameters(self, message, source):
+    def _get_v2_parameters(self, message, source, email_feedback):
         """V2-Style raw payload for `send_email`.
 
         https://boto3.amazonaws.com/v1/documentation/api/1.26.31/reference/services/sesv2.html#SESV2.Client.send_email
         """
         params = dict(
+            FeedbackForwardingEmailAddress=email_feedback,
             FromEmailAddress=source or message.from_email,
             Destination={
                 'ToAddresses': message.recipients()

--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -239,7 +239,7 @@ class SESBackend(BaseEmailBackend):
         recent_send_times.append(now)
         # end of throttling
 
-    def _get_send_email_parameters(self, message, source, email_feedack):   
+    def _get_send_email_parameters(self, message, source, email_feedack):
         return (self._get_v2_parameters(message, source, email_feedack)
                 if self._use_ses_v2
                 else self._get_v1_parameters(message, source))

--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -127,7 +127,8 @@ class SESBackend(BaseEmailBackend):
             return
 
         num_sent = 0
-        source = settings.AWS_SES_RETURN_PATH
+        source = settings.AWS_SES_FROM_EMAIL
+        email_feedback = settings.AWS_SES_RETURN_PATH
         for message in email_messages:
             # SES Configuration sets. If the AWS_SES_CONFIGURATION_SET setting
             # is not None, append the appropriate header to the message so that
@@ -159,7 +160,7 @@ class SESBackend(BaseEmailBackend):
             if self._throttle:
                 self._update_throttling()
 
-            kwargs = self._get_send_email_parameters(message, source)
+            kwargs = self._get_send_email_parameters(message, source, email_feedback)
 
             try:
                 response = (self.connection.send_email(**kwargs)
@@ -238,9 +239,8 @@ class SESBackend(BaseEmailBackend):
         recent_send_times.append(now)
         # end of throttling
 
-    def _get_send_email_parameters(self, message, source):
-        email_feedback = settings.AWS_SES_FROM_EMAIL
-        return (self._get_v2_parameters(message, source, email_feedback)
+    def _get_send_email_parameters(self, message, source, email_feedack):   
+        return (self._get_v2_parameters(message, source, email_feedack)
                 if self._use_ses_v2
                 else self._get_v1_parameters(message, source))
 

--- a/django_ses/settings.py
+++ b/django_ses/settings.py
@@ -38,6 +38,7 @@ AWS_SES_FROM_ARN = getattr(settings, 'AWS_SES_FROM_ARN', None)
 AWS_SES_RETURN_PATH_ARN = getattr(settings, 'AWS_SES_RETURN_PATH_ARN', None)
 
 USE_SES_V2 = getattr(settings, 'USE_SES_V2', False)
+AWS_SES_FROM_EMAIL = getattr(settings, 'USE_SES_EMAIL_FEEDBACK', None)
 
 TIME_ZONE = settings.TIME_ZONE
 

--- a/django_ses/settings.py
+++ b/django_ses/settings.py
@@ -38,7 +38,7 @@ AWS_SES_FROM_ARN = getattr(settings, 'AWS_SES_FROM_ARN', None)
 AWS_SES_RETURN_PATH_ARN = getattr(settings, 'AWS_SES_RETURN_PATH_ARN', None)
 
 USE_SES_V2 = getattr(settings, 'USE_SES_V2', False)
-AWS_SES_FROM_EMAIL = getattr(settings, 'USE_SES_EMAIL_FEEDBACK', None)
+AWS_SES_FROM_EMAIL = getattr(settings, 'AWS_SES_FROM_EMAIL', None)
 
 TIME_ZONE = settings.TIME_ZONE
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -336,9 +336,9 @@ class SESBackendTestReturn(TestCase):
         FakeSESConnection.outbox = []
     
     def test_from_email(self):
-        settings.AWS_SES_FROM_EMAIL = "return@example.com"
-        send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
-        self.assertEqual(self.outbox.pop()['Source'], 'return@example.com')
+        settings.AWS_SES_FROM_EMAIL = "my_default_from@example.com"
+        send_mail('subject', 'body', 'ignored_from@example.com', ['to@example.com'])
+        self.assertEqual(self.outbox.pop()['Source'], 'my_default_from@example.com')
     
     def test_return_path(self):
         settings.USE_SES_V2 = True

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -156,6 +156,7 @@ class SESBackendTest(TestCase):
         self.assertEqual(config_set_callable.dkim_selector, 'ses')
         self.assertEqual(config_set_callable.dkim_headers, ('From', 'To', 'Cc', 'Subject'))
 
+
 class SESV2BackendTest(TestCase):
     def setUp(self):
         django_settings.EMAIL_BACKEND = 'tests.test_backend.FakeSESBackend'
@@ -261,6 +262,15 @@ class SESV2BackendTest(TestCase):
         settings.AWS_SES_RETURN_PATH = None
         send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
         self.assertEqual(self.outbox.pop()['FromEmailAddress'], 'from@example.com')
+
+    def test_feedback_forwarding(self):
+        """
+        Ensure that the notification address argument uses FeedbackForwardingEmailAddress.
+        """
+        settings.AWS_SES_FROM_EMAIL = 'reply@example.com'
+
+        send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
+        self.assertEqual(self.outbox.pop()['FeedbackForwardingEmailAddress'], 'reply@example.com')
 
     def test_source_arn_is_NOT_set(self):
         """

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -344,4 +344,5 @@ class SESBackendTestReturn(TestCase):
         settings.USE_SES_V2 = True
         settings.AWS_SES_RETURN_PATH = "return@example.com"
         send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
+        self.assertEqual(self.outbox.pop()['Source'], 'from@example.com')
         self.assertEqual(self.outbox.pop()['FeedbackForwardingEmailAddress'], 'return@example.com')


### PR DESCRIPTION
- Foi adicionado o FeedbackForwardingEmailAddress como parâmetro de envio que permite receber e-mails de reclamação. Pela variável AWS_SES_FROM_EMAIL, conseguiríamos setar qual seria o e-mail para receber reclamações.